### PR TITLE
Fix description for AMI ID

### DIFF
--- a/14-InfrastructureAsCode (CloudFormation)/02-portable-template/portable-stage2.yaml
+++ b/14-InfrastructureAsCode (CloudFormation)/02-portable-template/portable-stage2.yaml
@@ -4,7 +4,7 @@ Parameters:
     Description: "Key Pair for EC2"
   AMIID:
     Type: "String"
-    Description: "Key Paur for EC2"
+    Description: "AMI ID for EC2"
 Resources:
   Bucket:
     Type: 'AWS::S3::Bucket'


### PR DESCRIPTION
Just a heads up: in this lesson [DEMO] Template v2 - Portable you state there is a link attached to this lesson with additional public parameters to review - but I only see the text description and no link. 